### PR TITLE
--pid and --sid parameters can take a list of ids now

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,15 @@ Using the `--pid` will only download a single episode
 python ruvsarpur.py --pid 4849075
 ```
 
+Both the `--sid` and `--pid` parameters support multiple ids
+
+```
+python ruvsarpur.py --sid 18457 21810
+```
+```
+python ruvsarpur.py --pid 4849075 4852060 4849078
+```
+
 Use the `-o` or `--output` argument to control where the video files will be saved to. Please make sure that you don't end your path with a backwards slash.
 ```
 python ruvsarpur.py --pid 4849075 -o "c:\videos\ruv"

--- a/docs/index.html
+++ b/docs/index.html
@@ -165,6 +165,15 @@ python ruvsarpur.py --list --find "Hvolpa" --desc
 <div class="code">python ruvsarpur.py --pid 4849075
 </div>
 
+<p>Both the <code>--sid</code> and <code>--pid</code> parameters support multiple ids</p>
+
+<div class="code">python ruvsarpur.py --sid 18457 21810
+</div>
+
+<div class="code">python ruvsarpur.py --pid 4849075 4852060 4849078
+</div>
+
+
 <p>Use the <code>-o</code> or <code>--output</code> argument to control where the video files will be saved to. Please make sure that you don't end your path with a backwards slash.</p>
 
 <div class="code">python ruvsarpur.py --pid 4849075 -o "c:\videos\ruv"

--- a/src/ruvsarpur.py
+++ b/src/ruvsarpur.py
@@ -234,9 +234,9 @@ def parseArguments():
   parser.add_argument("-o", "--output", help="The path to the folder where the downloaded files should be stored",
                                         type=str)
   parser.add_argument("--sid", help="The series id for the tv series that should be downloaded",
-                               type=str)
+                               type=str, nargs="+")
   parser.add_argument("--pid", help="The program id for a specific program entry that should be downloaded",
-                               type=str) 
+                               type=str, nargs="+")
 
   parser.add_argument("-c", "--category", 
                             choices=[1,2,3,4,5,6,7,9,13,17],
@@ -393,10 +393,10 @@ def runMain():
       
       # if the series id is set then find all shows belonging to that series
       if( args.sid is not None ):
-        if( 'sid' in schedule_item and args.sid == schedule_item['sid'] ):
+        if( 'sid' in schedule_item and schedule_item['sid'] in args.sid):
           download_list.append(schedule_item)
       elif( args.pid is not None ):
-        if( 'pid' in schedule_item and args.pid == schedule_item['pid'] ):
+        if( 'pid' in schedule_item and schedule_item['pid'] in args.pid):
           download_list.append(schedule_item)
       elif( args.find is not None ):
         if( 'title' in schedule_item and fuzz.partial_ratio( args.find, schedule_item['title'] ) > 80 ):
@@ -453,7 +453,7 @@ def runMain():
         # Store the id as already recorded 
         previously_recorded.append(item['pid'])
 
-        # Now save the list of already recorded shows back to file and exit
+        # Save the list of already recorded shows back to file
         savePreviouslyRecordedShows(previously_recorded,previously_recorded_file_name)
     
   finally:

--- a/src/ruvsarpur.py
+++ b/src/ruvsarpur.py
@@ -233,9 +233,9 @@ def parseArguments():
   
   parser.add_argument("-o", "--output", help="The path to the folder where the downloaded files should be stored",
                                         type=str)
-  parser.add_argument("--sid", help="The series id for the tv series that should be downloaded",
+  parser.add_argument("--sid", help="The series ids for the tv series that should be downloaded",
                                type=str, nargs="+")
-  parser.add_argument("--pid", help="The program id for a specific program entry that should be downloaded",
+  parser.add_argument("--pid", help="The program ids for the program entries that should be downloaded",
                                type=str, nargs="+")
 
   parser.add_argument("-c", "--category", 


### PR DESCRIPTION
Changed the --sid and --pid parameter so that they can now take a list of ids instead of a single id.  Allows you to download multiple episodes or series with a single invocation of the script.
