### PR TITLE
Added http://smooth.ruv.cache.is/lokad/{0}M{1}.mp4 as a URL schema

### DIFF
--- a/src/ruvsarpur.py
+++ b/src/ruvsarpur.py
@@ -64,6 +64,7 @@ TV_SCHEDULE_LOG_FILE = 'tvschedule.json'
 # The urls that should be tried when attempting to discover the actual video file on the server
 EP_URLS = [
             'http://smooth.ruv.cache.is/lokad/{0}R{1}.mp4',
+            'http://smooth.ruv.cache.is/lokad/{0}M{1}.mp4',
             'http://smooth.ruv.cache.is/opid/{0}R{1}.mp4'
           ]
              


### PR DESCRIPTION
Quick fix to support a new URL scheme I came across. This failed
`hansi@Hansi:~/Downloads$ ruv --pid 4896154
Found 1 show(s)
1 of 1: Hvolpasveitin (2 af 24) not found on server (pid=4896154)`

Actual URL is: http://smooth.ruv.cache.is/lokad/4896154M1.mp4

After change:
`hansi@Hansi:~/Downloads$ ruv --pid 4896154
Found 1 show(s)
1 of 1: Hvolpasveitin (2 af 24) | Total: 352 MB
 Downloading: |========-----------------| 32.2% Working`

It could be argued that opid might have the M addition too but didn't come across any. Also the R/M could be generalized as a third format option for the url but keeping it simple in a YAGNI fashion.