### PR TITLE
Attempt to find ffmpeg path in the environment

### DIFF
--- a/src/ruvsarpur.py
+++ b/src/ruvsarpur.py
@@ -58,6 +58,8 @@ from itertools import (takewhile,repeat) # To count lines for the extremely larg
 from requests.packages.urllib3.exceptions import InsecureRequestWarning
 requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 
+import utilities
+
 # Lambdas as shorthands for printing various types of data
 # See https://pypi.python.org/pypi/termcolor for more info
 color_title = lambda x: colored(x, 'cyan', 'on_grey')
@@ -890,6 +892,12 @@ def findffmpeg(path_to_ffmpeg_install=None, working_dir=None):
   bin_dist = os.path.join(working_dir, "..","bin","ffmpeg.exe" if platform.system() == 'Windows' else 'ffmpeg')
   if os.path.isfile(bin_dist):
     return str(Path(bin_dist).resolve())
+  
+  # Attempt to find ffmpeg in the environment
+  try:
+      return utilities.get_ffmpeg_location()
+  except Exception:
+      pass # Ignoring the exception
   
   # Throw an error
   raise ValueError('Could not locate FFMPEG install, please use the --ffmpeg switch to specify the path to the ffmpeg executable on your system.')

--- a/src/utilities.py
+++ b/src/utilities.py
@@ -1,0 +1,18 @@
+import shutil
+
+
+def get_ffmpeg_location():
+    """
+    Locate the ffmpeg executable in the system's PATH.
+
+    Returns:
+        str: The path to the ffmpeg executable.
+
+    Raises:
+        FileNotFoundError: If ffmpeg is not found in the PATH.
+    """
+    ffmpeg_path = shutil.which("ffmpeg")
+    if ffmpeg_path:
+        return ffmpeg_path
+    else:
+        raise FileNotFoundError("ffmpeg not found in PATH")


### PR DESCRIPTION
It's a bit of a pain to have to supply the path to ffmpeg when running on macOS. I finally checked if it would be simple to add this check as a final fallback mechanism, and it turned out to be quite simple.

I haven't tried it on Windows, [but looking at the documentation for shutils](https://docs.python.org/3/library/shutil.html), it seems like it should work. It works fine on macOS, so I expect it to work fine on Linux as well.